### PR TITLE
Add missing conditions to Cancel webhook

### DIFF
--- a/includes/class-wc-utrust-webhooks.php
+++ b/includes/class-wc-utrust-webhooks.php
@@ -109,7 +109,7 @@ if (!class_exists('UT_Webhooks')) {
                 return;
             } else {
 
-                if ('cancelled' === $order->get_status()) {
+                if ('cancelled' === $order->get_status() || 'processing' === $order->get_status() || 'completed' === $order->get_status()) {
                     return;
                 }
 


### PR DESCRIPTION
Why?
* When two webhook notifications (Paid + Cancelled) come in this Order, the plugin is changing an already paid order from Processing/Completed to Cancelled. This shouldn't be the case because when an Order is Paid in Utrust, there is no way to cancel it.

What?
* Add missing conditions for Processing and Completed when the webhook notification is from the Cancel type.